### PR TITLE
feat: make accounts avaiable in ledger variable

### DIFF
--- a/src/fava_dashboards/__init__.py
+++ b/src/fava_dashboards/__init__.py
@@ -92,11 +92,13 @@ class FavaDashboards(FavaExtensionBase):
     def bootstrap(self, dashboard_id):
         operating_currencies = self.ledger.options["operating_currency"]
         commodities = {c.currency: c for c in self.ledger.all_entries_by_type.Commodity}
+        accounts = self.ledger.accounts
         ledger = {
             "dateFirst": g.filtered._date_first,
             "dateLast": g.filtered._date_last - datetime.timedelta(days=1),
             "operatingCurrencies": operating_currencies,
             "ccy": operating_currencies[0],
+            "accounts": accounts,
             "commodities": commodities,
         }
 


### PR DESCRIPTION
It is useful to be able to access account meta.

For example in the asset classess, I have an account like this:
```beancount
2023-02-06 open Assets:Funds CNY
    asset_class: "Funds"

2023-02-05 commodity CNY
    asset_class: "Cash"

```

It is OTC Funds pricing in CNY,  though CNY commodity is Cash the Funds should not classify as Cash.