### PR TITLE
Include all price directives in BQL queries

### DIFF
--- a/src/fava_dashboards/__init__.py
+++ b/src/fava_dashboards/__init__.py
@@ -76,7 +76,7 @@ class FavaDashboards(FavaExtensionBase):
 
     def exec_query(self, query):
         try:
-            rtypes, rrows = run_query(g.filtered.entries, self.ledger.options, query)
+            rtypes, rrows = run_query(g.filtered.entries_with_all_prices, self.ledger.options, query)
         except Exception as ex:
             raise FavaAPIError(f"failed to execute query {query}: {ex}") from ex
 


### PR DESCRIPTION
Without this change, applying filters on account, tag, etc. on the fava UI causes all
price directives to be excluded from the queries used by the dashboards. Without the price directives available the BQL
CONVERT function does not work for commodities.

The entries_with_all_prices was recently added to the fava FilteredLedger API to
make it possible to address this issue: https://github.com/beancount/fava/pull/2005
