### PR TITLE
Reduce test flakiness by applying a timeout

### DIFF
--- a/frontend/tests/e2e/dashboards.test.ts
+++ b/frontend/tests/e2e/dashboards.test.ts
@@ -20,6 +20,8 @@ test.describe("PNG Snapshot Tests", () => {
           document.body.style.height = "inherit";
         });
         await page.waitForLoadState("networkidle");
+        // reduce flakiness by waiting for React to update with the fetched data
+        await page.waitForTimeout(200);
         await expect(page).toHaveScreenshot({ fullPage: true });
       });
     });
@@ -35,6 +37,8 @@ test.describe("PNG Snapshot Tests", () => {
           document.body.style.height = "inherit";
         });
         await page.waitForLoadState("networkidle");
+        // reduce flakiness by waiting for React to update with the fetched data
+        await page.waitForTimeout(200);
         await expect(page).toHaveScreenshot({ fullPage: true });
       });
     });


### PR DESCRIPTION
I've observed some test flakiness both on local machine and on CI/CD just now (the latter is a bit more annoying as it requires to push an effectively no-op commit). It seems that the cause is that some dashboard panels appear grey on the screenshots. I think the reason is that while it waits for all the network operations to halt, some of the hooks/React processing may not finish yet.

This probably should help, although I think time would be the only confirmation.

One drawback though is GitHub Actions getting a bit longer (although if there would be less screenshot retries, maybe it would be even faster on average), I hope they are not priced in the way this sort of change would incur any additional costs.