### PR TITLE
update installation instructions to install latest beta version

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Example dashboards with random data:
 
 ## Installation
 ```
-pip install fava-dashboards
+pip install "fava-dashboards>=2.0.0b6"
 ```
 
 Enable this plugin in Fava by adding the following lines to your ledger:


### PR DESCRIPTION
The README describes the new dashboard format (`dashboards.tsx`), however when following the instructions, fava-dashboards v1 will be installed. Therefore, let's update the README to install the latest beta version.

Resolves: #177