### PR TITLE
fix: do not reuse Panel instance when switching dashboard

### DIFF
--- a/frontend/src/routes/dashboard.tsx
+++ b/frontend/src/routes/dashboard.tsx
@@ -92,7 +92,9 @@ function DashboardGrid({ dashboard }: DashboardGridProps) {
         {isPending || !ledger ? (
           <Skeleton width="100%" height={600} sx={{ margin: 1 }} />
         ) : (
-          dashboard.panels.map((panel, i) => <PanelCard key={i} ledger={ledger} dashboard={dashboard} panel={panel} />)
+          dashboard.panels.map((panel, i) => (
+            <PanelCard key={`${dashboard.name}-${i}`} ledger={ledger} dashboard={dashboard} panel={panel} />
+          ))
         )}
       </Stack>
     </>


### PR DESCRIPTION
Key dashboard panels by dashboard name and panel index, so React remounts panel cards when the selected dashboard changes. This prevents @tanstack/query's keepPreviousData placeholder from showing content from the previous dashboard while the new panel is loading.

Resolves: #185